### PR TITLE
Switched from System.Net.Mail.SmtpClient to Mailkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ If you have large PDFs with many pages or if you turn on parallel processing, en
 | Smtp.Subject |  Subject of the email | No | - | string |
 | Smtp.From |  Sender of the email | No | - | string |
 | Smtp.To |  Recipient of the email | No | - | string |
+| Smtp.Username |  Username for Smtp server | No | - | string |
+| Smtp.Password |  Password for Smtp server | No | - | string |
 | Ocr.Scale |  Target scaling of the PDF | Yes | 300 | int |
 | Ocr.Deskew |  Correct rotation of the PDF | Yes | True | bool |
 | Ocr.DeliveryNoteDetectionRegex |  Regex to detect the delivery note number | Yes | (LIEF).\\d* | string |

--- a/src/DocToIdoit/DocToIdoit.csproj
+++ b/src/DocToIdoit/DocToIdoit.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="IronOcr" Version="2022.12.10830" />
     <PackageReference Include="IronOcr.Languages.German" Version="2020.11.2" />
     <PackageReference Include="IronOcr.Linux" Version="2022.12.10830" />
+    <PackageReference Include="MailKit" Version="3.4.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Systemd" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="6.0.1" />

--- a/src/DocToIdoit/Interfaces/ISmtpWorker.cs
+++ b/src/DocToIdoit/Interfaces/ISmtpWorker.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net.Mail;
 using System.Threading.Tasks;
 
@@ -12,10 +13,9 @@ namespace DocToIdoit
         /// <summary>
         /// Send an E-mail.
         /// </summary>
-        /// <param name="body"></param>
-        /// <param name="attachment"></param>
-        /// <param name="attachment2"></param>
+        /// <param name="body">Message body</param>
+        /// <param name="attachments">Paths to files which should be attached</param>
         /// <returns></returns>
-        Task SendAsync(string body, Attachment attachment = null, Attachment attachment2 = null);
+        Task SendAsync(string body, IEnumerable<string> attachments);
     }
 }

--- a/src/DocToIdoit/Workers/ServiceWorker.cs
+++ b/src/DocToIdoit/Workers/ServiceWorker.cs
@@ -302,10 +302,10 @@ namespace DocToIdoit
             {
                 using var scope = _services.CreateScope();
                 using var smtpWorker = scope.ServiceProvider.GetRequiredService<ISmtpWorker>();
+                var attachments = new List<string>() { string.Format(_configuration["Logging:File:Path"], DateTime.UtcNow), filePath };
                 //send email with current log file as attachment
                 await smtpWorker.SendAsync($"While processing file {fileName}, errors occurred.\nCheck the log file for more information.",
-                    new Attachment(string.Format(_configuration["Logging:File:Path"], DateTime.UtcNow)),
-                    new Attachment(filePath));
+                    attachments);
             }
             File.Move(filePath, _configuration["Watcher:ErrorScanPath"] + Path.GetFileName(fileName), true);
             _logger.LogInformation($"Moved file {fileName} to error directory");

--- a/src/DocToIdoit/Workers/SmtpWorker.cs
+++ b/src/DocToIdoit/Workers/SmtpWorker.cs
@@ -57,6 +57,8 @@ namespace DocToIdoit
             message.Body = builder.ToMessageBody();
             try
             {
+                if (_configuration["Smtp:Username"] != string.Empty && _configuration["Smtp:Password"] != string.Empty)
+                    await _smtpClient.AuthenticateAsync(_configuration["Smtp:Username"], _configuration["Smtp:Password"]);
                 await _smtpClient.ConnectAsync(_configuration["Smtp:Server"],
                                                     _configuration.GetValue<int>("Smtp:Port"));
                 await _smtpClient.SendAsync(message);

--- a/src/DocToIdoit/appsettings.json
+++ b/src/DocToIdoit/appsettings.json
@@ -52,7 +52,9 @@
     "Port": 25,
     "Subject": "",
     "From": "",
-    "To": ""
+    "To": "",
+    "Username": "",
+    "Password": ""
   },
   "Watcher": {
     "ScanPath": "/ocr/scan/",


### PR DESCRIPTION
Due to recommendation from Microsoft [System.Net.Mail.SmtpClient](https://learn.microsoft.com/de-de/dotnet/api/system.net.mail.smtpclient?view=net-7.0) this pull request switches provides the switch from System.Net.Mail.SmtpClient to Mailkit.

Additionally it is now supported to use authentication and ssl for smtp.